### PR TITLE
Update guide with latest boot features

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -117,21 +117,28 @@ Here you create an Application class with all the components.
 include::complete/src/main/java/hello/Application.java[]
 ----
 
-In the configuration, you need to add the `@EnableMongoRepositories` annotation. This annotation tells Spring Data MongoDB to seek out any interface that extends `org.springframework.data.repository.Repository` and to automatically generate an implementation. By extending `MongoRepository`, your `CustomerRepository` interface transitively extends `Repository`. Therefore, Spring Data MongoDB will find it and create an implementation for you.
+In the configuration, you only need to add the usual `@EnableAutoConfiguration` as our repository is located
+in the same package;  Spring Boot will handle those repositories automatically as long as they are included
+in the same package (or a sub-package) of your @EnableAutoConfiguration class. For more control over the
+registration process, you can use the `@EnableMongoRepositories` annotation.
 
+Spring Data MongoDB uses the `MongoTemplate` to execute the queries behind your `find*` methods. You can
+use the template yourself for more complex queries, but this guide doesn't cover that.
 
-* The `Mongo` connection links the application to your MongoDB server
-* Spring Data MongoDB uses the `MongoTemplate` to execute the queries behind your `find*` methods. You can use the template yourself for more complex queries, but this guide doesn't cover that.
-* Finally, you autowire an instance of `CustomerRepository`. Spring Data MongoDB dynamically creates a proxy and injects it there.
-
-`Application` includes a `main()` method that puts the `CustomerRepository` through a few tests. First, it fetches the `CustomerRepository` from the Spring application context. Then it saves a handful of `Customer` objects, demonstrating the `save()` method and setting up some data to work with. Next, it calls `findAll()` to fetch all `Customer` objects from the database. Then it calls `findByFirstName()` to fetch a single `Customer` by her first name. Finally, it calls `findByLastName()` to find all customers whose last name is "Smith".
+`Application` includes a `main()` method that autowire an instance of `CustomerRepository`: Spring Data
+MongoDB dynamically creates a proxy and injects it there. We use the `CustomerRepository` through a few
+tests. First, it saves a handful of `Customer` objects, demonstrating the `save()` method and setting
+up some data to work with. Next, it calls `findAll()` to fetch all `Customer` objects from the database.
+Then it calls `findByFirstName()` to fetch a single `Customer` by her first name. Finally, it calls
+`findByLastName()` to find all customers whose last name is "Smith".
 
 include::https://raw.github.com/spring-guides/getting-started-macros/master/build_an_executable_jar_mainhead.adoc[]
 include::https://raw.github.com/spring-guides/getting-started-macros/master/build_an_executable_jar_with_both.adoc[]
     
 include::https://raw.github.com/spring-guides/getting-started-macros/master/run_the_application_with_both.adoc[]
     
-You should see something like this (with other stuff like queries as well):
+As our `Application` implements `CommandLineRunner`, the `run` method is invoked automatically when boot
+starts. You should see something like this (with other stuff like queries as well):
 ....
 == Customers found with findAll():
 Customer[id=51df1b0a3004cb49c50210f8, firstName='Alice', lastName='Smith']

--- a/complete/src/main/java/hello/Application.java
+++ b/complete/src/main/java/hello/Application.java
@@ -4,11 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
-@ComponentScan
 @EnableAutoConfiguration
 public class Application implements CommandLineRunner {
 


### PR DESCRIPTION
This commit removes the `@Configuration` and `@ComponentScan` annotations for the solution. 

`@Configuration` was never meant to be there and component scanning is enabled by default for components in the same package as the application class.

Besides, the guide was outdated as it refers to `@EnableMongoRepositories`
