### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 :icons: font
 :source-highlighter: prettify
 :project_id: gs-accessing-data-mongodb
-This guide walks you through the process of using http://projects.spring.io/spring-data-mongodb/[Spring Data MongoDB] to build an application that stores data in and retrieves it from http://www.mongodb.org/[MongoDB], a document-based database.
+This guide walks you through the process of using https://projects.spring.io/spring-data-mongodb/[Spring Data MongoDB] to build an application that stores data in and retrieves it from https://www.mongodb.org/[MongoDB], a document-based database.
 
 
 == What you'll build
@@ -36,7 +36,7 @@ With MacPorts:
 
     $ port install mongodb
 
-For other systems with package management, such as Redhat, Ubuntu, Debian, CentOS, and Windows, see instructions at http://docs.mongodb.org/manual/installation/.
+For other systems with package management, such as Redhat, Ubuntu, Debian, CentOS, and Windows, see instructions at https://docs.mongodb.org/manual/installation/.
 
 After you install MongoDB, launch it in a console window. This command also starts up a server process.
 
@@ -70,7 +70,7 @@ The other two properties, `firstName` and `lastName`, are left unannotated. It i
 
 The convenient `toString()` method will print out the details about a customer.
 
-NOTE: MongoDB stores data in collections. Spring Data MongoDB will map the class `Customer` into a collection called _customer_. If you want to change the name of the collection, you can use Spring Data MongoDB's http://docs.spring.io/spring-data/data-mongodb/docs/current/api/org/springframework/data/mongodb/core/mapping/Document.html[`@Document`] annotation on the class.
+NOTE: MongoDB stores data in collections. Spring Data MongoDB will map the class `Customer` into a collection called _customer_. If you want to change the name of the collection, you can use Spring Data MongoDB's https://docs.spring.io/spring-data/data-mongodb/docs/current/api/org/springframework/data/mongodb/core/mapping/Document.html[`@Document`] annotation on the class.
 
 
 == Create simple queries
@@ -122,7 +122,7 @@ up some data to work with. Next, it calls `findAll()` to fetch all `Customer` ob
 Then it calls `findByFirstName()` to fetch a single `Customer` by her first name. Finally, it calls
 `findByLastName()` to find all customers whose last name is "Smith".
 
-NOTE: Spring Boot by default attempts to connect to a locally hosted instance of MongoDB. Read the http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-mongodb[reference docs] for details on pointing your app to an instance of MongoDB hosted elsewhere.
+NOTE: Spring Boot by default attempts to connect to a locally hosted instance of MongoDB. Read the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-mongodb[reference docs] for details on pointing your app to an instance of MongoDB hosted elsewhere.
 
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/master/build_an_executable_jar_mainhead.adoc[]
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/master/build_an_executable_jar_with_both.adoc[]


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://projects.spring.io/spring-data-mongodb/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-mongodb/ ([https](https://projects.spring.io/spring-data-mongodb/) result 200).
* [ ] http://docs.mongodb.org/manual/installation/ with 1 occurrences migrated to:  
  https://docs.mongodb.org/manual/installation/ ([https](https://docs.mongodb.org/manual/installation/) result 301).
* [ ] http://docs.spring.io/spring-data/data-mongodb/docs/current/api/org/springframework/data/mongodb/core/mapping/Document.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-mongodb/docs/current/api/org/springframework/data/mongodb/core/mapping/Document.html ([https](https://docs.spring.io/spring-data/data-mongodb/docs/current/api/org/springframework/data/mongodb/core/mapping/Document.html) result 301).
* [ ] http://www.mongodb.org/ with 1 occurrences migrated to:  
  https://www.mongodb.org/ ([https](https://www.mongodb.org/) result 301).